### PR TITLE
Reset the order comments in the checkout session

### DIFF
--- a/Plugin/Model/Checkout/PaymentInformationManagement.php
+++ b/Plugin/Model/Checkout/PaymentInformationManagement.php
@@ -118,6 +118,7 @@ class PaymentInformationManagement
                 $history->save();
                 $order->setCustomerNote($comment);
                 $order->save();
+                $checkoutSession->setOrderCommentstext("");
             }
         }
     }


### PR DESCRIPTION
If a user does not type in a comment and places an order, the previous order's comment is saved in the new order. Need to reset the comment in the checkoutSession (i.e set it to empty string) when the comment is saved in the order to prevent this from happening.