### PR TITLE
#8  Guest checkout doesn't save comment

### DIFF
--- a/Plugin/Model/Checkout/PaymentInformationManagement.php
+++ b/Plugin/Model/Checkout/PaymentInformationManagement.php
@@ -121,5 +121,7 @@ class PaymentInformationManagement
                 $checkoutSession->setOrderCommentstext("");
             }
         }
+
+        return $orderId;
     }
 }


### PR DESCRIPTION
aroundPlaceOrder should return order Id as original method
because we use this order id in aroundSavePaymentInformationAndPlaceOrder  method
to save comment for needed order, previously orderId was null - that is the reason comment was not saved.